### PR TITLE
Upgrade to OpenSearch Dashboards 2.16

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,20 +32,17 @@ jobs:
           repository: opensearch-project/OpenSearch-Dashboards
           ref: ${{ steps.osd_version.outputs.version }}
           path: osd
-      - name: Get node and yarn versions
-        id: versions
-        run: |
-          echo "::set-output name=node_version::$(node -p "(require('./osd/package.json').engines.node).match(/[.0-9]+/)[0]")"
-          echo "::set-output name=yarn_version::$(node -p "require('./osd/package.json').engines.yarn")"
       - name: Setup node
-        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # 3.6.0
+        uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # 4.0.1
         with:
-          node-version: ${{ steps.versions.outputs.node_version }}
+          node-version-file: './OpenSearch-Dashboards/.nvmrc'
+          registry-url: 'https://registry.npmjs.org'
       - name: Setup yarn
         run: |
           npm uninstall -g yarn
-          echo "Installing yarn ${{ steps.versions.outputs.yarn_version }}"
-          npm i -g yarn@${{ steps.versions.outputs.yarn_version }}
+          YARN_VERSION=$(node -p "require('./OpenSearch-Dashboards/package.json').engines.yarn")
+          echo "Installing yarn @$YARN_VERSION"
+          npm i -g yarn@$YARN_VERSION
       - name: Move plugin to OpenSearch Dashboards folder
         run: |
           mkdir -p osd/plugins

--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -1,7 +1,7 @@
 {
   "id": "radarVisPlugin",
   "version": "0.21.2",
-  "opensearchDashboardsVersion": "2.11.1",
+  "opensearchDashboardsVersion": "2.16.0",
   "server": false,
   "ui": true,
   "requiredPlugins": [

--- a/releases/unreleased/upgrade-opensearch-dashboards-version-to-216.yml
+++ b/releases/unreleased/upgrade-opensearch-dashboards-version-to-216.yml
@@ -1,0 +1,8 @@
+---
+title: Upgrade to OpenSearch Dashboards 2.16
+category: dependency
+author: Eva Millán <evamillan@bitergia.com>
+issue: null
+notes: >
+  OpenSearch Dashboards 2.16 fixes an issue with the colors of the 
+  visualizations when there are more than 10 items.


### PR DESCRIPTION
Bumps OpenSearch Dashboards to version 2.16 and updates how the Node version is resolved in the GitHub workflow.